### PR TITLE
Update code for newer numpy versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,234 @@
+# Editor temporary/working/backup files #
+#########################################
+.#*
+[#]*#
+*~
+*$
+*.bak
+*.diff
+.idea/
+*.iml
+*.ipr
+*.iws
+*.org
+.project
+pmip
+*.rej
+.settings/
+.*.sw[nop]
+.sw[nop]
+*.tmp
+*.vim
+.vscode
+tags
+cscope.out
+# gnu global
+GPATH
+GRTAGS
+GSYMS
+GTAGS
+.cache
+.mypy_cache/
+
+# Compiled source #
+###################
+*.a
+*.com
+*.class
+*.dll
+*.exe
+*.o
+*.o.d
+*.py[ocd]
+*.so
+
+# Packages #
+############
+# it's better to unpack these files and commit the raw source
+# git has its own built in compression methods
+*.7z
+*.bz2
+*.bzip2
+*.dmg
+*.gz
+*.iso
+*.jar
+*.rar
+*.tar
+*.tbz2
+*.tgz
+*.zip
+
+# Python files #
+################
+# meson build/installation directories
+build
+build-install
+# meson python output
+.mesonpy-native-file.ini
+# sphinx build directory
+_build
+# setup.py dist directory
+dist
+doc/build
+doc/docenv
+doc/cdoc/build
+# Egg metadata
+*.egg-info
+# The shelf plugin uses this dir
+./.shelf
+MANIFEST
+.cache
+pip-wheel-metadata
+.python-version
+
+# Paver generated files #
+#########################
+/release
+
+# Logs and databases #
+######################
+*.log
+*.sql
+*.sqlite
+
+# Patches #
+###########
+*.patch
+*.diff
+
+# OS generated files #
+######################
+.DS_Store*
+.VolumeIcon.icns
+.fseventsd
+Icon?
+.gdb_history
+ehthumbs.db
+Thumbs.db
+.directory
+
+# pytest generated files #
+##########################
+/.pytest_cache
+
+# doc build generated files #
+#############################
+doc/source/savefig/
+
+
+# Things specific to this project #
+###################################
+numpy/core/__svn_version__.py
+doc/numpy.scipy.org/_build
+numpy/__config__.py
+numpy/core/include/numpy/__multiarray_api.h
+numpy/core/include/numpy/__ufunc_api.h
+numpy/core/include/numpy/_numpyconfig.h
+site.cfg
+.tox
+numpy/core/include/numpy/__multiarray_api.c
+numpy/core/include/numpy/__ufunc_api.c
+numpy/core/include/numpy/__umath_generated.c
+numpy/core/include/numpy/_umath_doc_generated.h
+numpy/core/include/numpy/config.h
+numpy/core/lib/
+numpy/core/src/common/npy_sort.h
+numpy/core/src/common/templ_common.h
+numpy/core/src/multiarray/_multiarray_tests.c
+numpy/core/src/multiarray/arraytypes.c
+numpy/core/src/multiarray/einsum.c
+numpy/core/src/multiarray/einsum_sumprod.c
+numpy/core/src/multiarray/lowlevel_strided_loops.c
+numpy/core/src/multiarray/multiarray_tests.c
+numpy/core/src/multiarray/nditer_templ.c
+numpy/core/src/multiarray/scalartypes.c
+numpy/core/src/multiarray/textreading/tokenize.c
+numpy/core/src/npymath/ieee754.c
+numpy/core/src/npymath/npy_math_complex.c
+numpy/core/src/npymath/npy_math_internal.h
+numpy/core/src/npysort/binsearch.c
+numpy/core/src/npysort/heapsort.c
+numpy/core/src/npysort/mergesort.c
+numpy/core/src/npysort/quicksort.c
+numpy/core/src/npysort/radixsort.c
+numpy/core/src/npysort/selection.c
+numpy/core/src/npysort/timsort.c
+numpy/core/src/npysort/sort.c
+numpy/core/src/private/npy_binsearch.h
+numpy/core/src/private/npy_partition.h
+numpy/core/src/private/templ_common.h
+numpy/core/src/umath/_umath_tests.c
+numpy/core/src/umath/scalarmath.c
+numpy/core/src/umath/funcs.inc
+numpy/core/src/umath/clip.[ch]
+numpy/core/src/umath/loops.[ch]
+numpy/core/src/umath/matmul.[ch]
+numpy/core/src/umath/operand_flag_tests.c
+numpy/core/src/umath/simd.inc
+numpy/core/src/umath/struct_ufunc_test.c
+numpy/core/src/umath/test_rational.c
+numpy/core/src/umath/umath_tests.c
+numpy/core/src/umath/loops_utils.h
+numpy/core/src/umath/loops_modulo.dispatch.c
+numpy/distutils/__config__.py
+numpy/linalg/umath_linalg.c
+doc/source/**/generated/
+benchmarks/results
+benchmarks/html
+benchmarks/env
+benchmarks/numpy
+benchmarks/_asv_compare.conf.json
+# cythonized files
+cythonize.dat
+numpy/random/_mtrand/_mtrand.c
+numpy/random/*.c
+numpy/random/legacy/*.c
+numpy/random/_mtrand/randint_helpers.pxi
+numpy/random/bounded_integers.pyx
+numpy/random/bounded_integers.pxd
+numpy/random/lib/npyrandom.lib
+tools/swig/test/Array_wrap.cxx
+tools/swig/test/Farray_wrap.cxx
+tools/swig/test/Farray.py
+tools/swig/test/Flat_wrap.cxx
+tools/swig/test/Flat.py
+tools/swig/test/Fortran_wrap.cxx
+tools/swig/test/Fortran.py
+tools/swig/test/Matrix_wrap.cxx
+tools/swig/test/Matrix.py
+tools/swig/test/Tensor_wrap.cxx
+tools/swig/test/Tensor.py
+tools/swig/test/Vector.py
+tools/swig/test/Vector_wrap.cxx
+tools/swig/test/Array.py
+
+# SIMD generated files #
+###################################
+# config headers of dispatchable sources
+*.dispatch.h
+# wrapped sources of dispatched targets, e.g. *.dispatch.avx2.c
+*.dispatch.*.c
+# _simd module
+numpy/core/src/_simd/_simd.dispatch.c
+numpy/core/src/_simd/_simd_data.inc
+numpy/core/src/_simd/_simd_inc.h
+# umath module
+numpy/core/src/umath/loops_unary.dispatch.c
+numpy/core/src/umath/loops_unary_fp.dispatch.c
+numpy/core/src/umath/loops_arithm_fp.dispatch.c
+numpy/core/src/umath/loops_arithmetic.dispatch.c
+numpy/core/src/umath/loops_logical.dispatch.c
+numpy/core/src/umath/loops_minmax.dispatch.c
+numpy/core/src/umath/loops_trigonometric.dispatch.c
+numpy/core/src/umath/loops_exponent_log.dispatch.c
+numpy/core/src/umath/loops_umath_fp.dispatch.c
+numpy/core/src/umath/loops_hyperbolic.dispatch.c
+numpy/core/src/umath/loops_modulo.dispatch.c
+numpy/core/src/umath/loops_comparison.dispatch.c
+# npysort module
+numpy/core/src/npysort/x86-qsort.dispatch.c
+numpy/core/src/npysort/x86-qsort.dispatch.*.cpp
+# multiarray module
+numpy/core/src/multiarray/argfunc.dispatch.c
+numpy/core/src/multiarray/arraytypes.h

--- a/ndarray_ducktypes/ArrayCollection.py
+++ b/ndarray_ducktypes/ArrayCollection.py
@@ -744,10 +744,6 @@ def setup_ducktype():
     def shape(a):
         return a.shape
 
-    @implements(np.alen)
-    def alen(a):
-        return len(a)
-
     @implements(np.ndim)
     def ndim(a):
         return a.ndim

--- a/ndarray_ducktypes/MaskedArray.py
+++ b/ndarray_ducktypes/MaskedArray.py
@@ -1759,29 +1759,29 @@ def _move_reduction_axis_last(a, axis=None):
 def median(a, axis=None, out=None, overwrite_input=False, keepdims=False):
     return np.quantile(a, 0.5, axis=axis, out=out,
                         overwrite_input=overwrite_input,
-                        interpolation='midpoint', keepdims=keepdims)
+                        method='midpoint', keepdims=keepdims)
 
 @implements(np.percentile)
 def percentile(a, q, axis=None, out=None, overwrite_input=False,
-               interpolation='linear', keepdims=False):
+               method='linear', keepdims=False):
     q = np.true_divide(q, 100)
     q = np.asanyarray(q)  # undo any decay the ufunc performed (gh-13105)
     if not _quantile_is_valid(q):
         raise ValueError("Percentiles must be in the range [0, 100]")
     return _quantile_unchecked(
-        a, q, axis, out, overwrite_input, interpolation, keepdims)
+        a, q, axis, out, overwrite_input, method, keepdims)
 
 @implements(np.quantile)
 def quantile(a, q, axis=None, out=None, overwrite_input=False,
-             interpolation='linear', keepdims=False):
+             method='linear', keepdims=False):
     q = np.asanyarray(q)
     if not _quantile_is_valid(q):
         raise ValueError("Quantiles must be in the range [0, 1]")
     return _quantile_unchecked(
-        a, q, axis, out, overwrite_input, interpolation, keepdims)
+        a, q, axis, out, overwrite_input, method, keepdims)
 
 def _quantile_unchecked(a, q, axis=None, out=None, overwrite_input=False,
-                        interpolation='linear', keepdims=False):
+                        method='linear', keepdims=False):
     """Assumes that q is in [0, 1], and is an ndarray"""
 
     a = as_duck_cls(a, base=MaskedArray)
@@ -1812,7 +1812,7 @@ def _quantile_unchecked(a, q, axis=None, out=None, overwrite_input=False,
         if dat.size == 0:
             outarr[oind] = X
         else:
-            outarr[oind] = np.quantile(dat, q, interpolation=interpolation)
+            outarr[oind] = np.quantile(dat, q, method=method)
 
     if out is not None:
         return out

--- a/ndarray_ducktypes/MaskedArray.py
+++ b/ndarray_ducktypes/MaskedArray.py
@@ -3575,13 +3575,6 @@ def shape(a):
     a = as_duck_cls(a, base=MaskedArray)
     return a.shape
 
-@implements(np.alen)
-def alen(a):
-    try:
-        return len(a)
-    except TypeError:
-        return len(get_duck_cls(a, base=MaskedArray)(a, ndmin=1))
-
 @implements(np.ndim)
 def ndim(a):
     a = as_duck_cls(a, base=MaskedArray)

--- a/ndarray_ducktypes/MaskedArray.py
+++ b/ndarray_ducktypes/MaskedArray.py
@@ -3092,8 +3092,7 @@ def flatnonzero(a):
     return np.nonzero(np.ravel(a))[0]
 
 @implements(np.histogram, checked_args=('a',))
-def histogram(a, bins=10, range=None, normed=None, weights=None,
-              density=None):
+def histogram(a, bins=10, range=None, density=None, weights=None):
     a = as_duck_cls(a, base=MaskedArray)
     if isinstance(bins, (MaskedArray, MaskedScalar)):
         raise ValueError("bins must not be a MaskedArray")
@@ -3108,10 +3107,10 @@ def histogram(a, bins=10, range=None, normed=None, weights=None,
     if weights is not None:
         weights = weights.ravel()[keep]
 
-    return np.histogram(dat, bins, range, normed, weights, density)
+    return np.histogram(dat, bins, range, density, weights)
 
 @implements(np.histogram2d, checked_args=('x', 'y'))
-def histogram2d(x, y, bins=10, range=None, normed=None, weights=None,
+def histogram2d(x, y, bins=10, range=None, weights=None,
                 density=None):
     try:
         N = len(bins)
@@ -3121,12 +3120,11 @@ def histogram2d(x, y, bins=10, range=None, normed=None, weights=None,
     if N != 1 and N != 2:
         xedges = yedges = np.asarray(bins)  # bins should become ndarray
         bins = [xedges, yedges]
-    hist, edges = histogramdd([x, y], bins, range, normed, weights, density)
+    hist, edges = histogramdd([x, y], bins, range, density, weights)
     return hist, edges[0], edges[1]
 
 @implements(np.histogramdd)
-def histogramdd(sample, bins=10, range=None, normed=None, weights=None,
-                density=None):
+def histogramdd(sample, bins=10, range=None, density=None, weights=None):
     if not np.isscalar(bins):
         for b in bins:
             if isinstance(b, (MaskedArray, MaskedScalar)):
@@ -3151,7 +3149,7 @@ def histogramdd(sample, bins=10, range=None, normed=None, weights=None,
     if weights is not None:
         weights = weights[keep]
 
-    return np.histogramdd(sample, bins, range, normed, weights, density)
+    return np.histogramdd(sample, bins, range, density, weights)
 
 @implements(np.histogram_bin_edges)
 def histogram_bin_edges(a, bins=10, range=None, weights=None):

--- a/ndarray_ducktypes/duckprint.py
+++ b/ndarray_ducktypes/duckprint.py
@@ -17,8 +17,7 @@ from numpy import (concatenate, errstate, array, format_float_positional,
 from numpy.core import umath
 
 from numpy.lib import NumpyVersion
-if (NumpyVersion(np.__version__) < '1.15.10' or
-        os.environ.get('NUMPY_EXPERIMENTAL_ARRAY_FUNCTION', '0') == '0'):
+if os.environ.get('NUMPY_EXPERIMENTAL_ARRAY_FUNCTION', '1') == '0':
     raise Exception("numpy __array_function__ must be enabled")
 
 

--- a/scratchwork/scratch.py
+++ b/scratchwork/scratch.py
@@ -67,7 +67,7 @@ def test_coverage():
     'np.argmax', 'np.argmin', 'np.searchsorted', 'np.resize', 'np.squeeze',
     'np.diagonal', 'np.trace', 'np.ravel', 'np.nonzero', 'np.shape',
     'np.compress', 'np.clip', 'np.sum', 'np.any', 'np.all', 'np.cumsum',
-    'np.ptp', 'np.amax', 'np.amin', 'np.alen', 'np.prod', 'np.cumprod',
+    'np.ptp', 'np.amax', 'np.amin', 'np.prod', 'np.cumprod',
     'np.ndim', 'np.size', 'np.around', 'np.mean', 'np.std', 'np.var',
     'np.round_', 'np.product', 'np.cumproduct', 'np.sometrue', 'np.alltrue',
     'np.rank', 'np.array2string', 'np.array_repr', 'np.array_str',

--- a/tests/test_MaskedArray.py
+++ b/tests/test_MaskedArray.py
@@ -2019,6 +2019,8 @@ class TestMaskedArrayInPlaceArithmetics:
     def test_inplace_floor_division_scalar_type(self):
         # Test of inplace division
         for t in self.othertypes:
+            if t == np.csingle or t == np.cdouble or t == np.clongdouble:
+                continue
             with warnings.catch_warnings(record=True) as w:
                 warnings.filterwarnings("always")
                 (x, y, xm) = (_.astype(t) for _ in self.uint8data)
@@ -2035,6 +2037,8 @@ class TestMaskedArrayInPlaceArithmetics:
     def test_inplace_floor_division_array_type(self):
         # Test of inplace division
         for t in self.othertypes:
+            if t == np.csingle or t == np.cdouble or t == np.clongdouble:
+                continue
             with warnings.catch_warnings(record=True) as w:
                 warnings.filterwarnings("always")
                 (x, y, xm) = (_.astype(t) for _ in self.uint8data)

--- a/tests/test_MaskedArray.py
+++ b/tests/test_MaskedArray.py
@@ -5130,16 +5130,13 @@ class Test_API:
                   8]'''))
 
     def test_api_attr_methods(self):
-        # shape alen ndim size
+        # shape ndim size
 
         d = [[1,2,3], [4,X,X]]
         a = MaskedArray(d)
 
         assert_equal(np.shape(a), (2,3))
         assert_equal(ma.shape(d), (2,3))
-
-        assert_equal(np.alen(a), 2)
-        assert_equal(ma.alen(d), 2)
 
         assert_equal(np.ndim(a), 2)
         assert_equal(ma.ndim(d), 2)

--- a/tests/test_MaskedArray.py
+++ b/tests/test_MaskedArray.py
@@ -108,7 +108,7 @@ def assert_almost_masked_equal(actual, desired, err_msg='', anymask=False):
 class TestMaskedArray:
     # Base test class for MaskedArrays.
 
-    def setup(self):
+    def setup_method(self):
         # Base data definition.
         x = np.array([1., 1., 1., -2., pi/2.0, 4., 5., -10., 10., 1., 2., 3.])
         y = np.array([5., 0., 3., 2., -1., -4., 0., -10., 10., 1., 0., 3.])
@@ -770,7 +770,7 @@ class TestMaskedArray:
 class TestMaskedArrayArithmetic:
     # Base test class for MaskedArrays.
 
-    def setup(self):
+    def setup_method(self):
         # Base data definition.
         x = np.array([1., 1., 1., -2., pi/2.0, 4., 5., -10., 10., 1., 2., 3.])
         y = np.array([5., 0., 3., 2., -1., -4., 0., -10., 10., 1., 0., 3.])
@@ -786,7 +786,7 @@ class TestMaskedArrayArithmetic:
         self.err_status = np.geterr()
         np.seterr(divide='ignore', invalid='ignore')
 
-    def teardown(self):
+    def teardown_method(self):
         np.seterr(**self.err_status)
 
     def test_basic_arithmetic(self):
@@ -1526,14 +1526,14 @@ class TestFillingValues:
 class TestUfuncs:
     # Test class for the application of ufuncs on MaskedArrays.
 
-    def setup(self):
+    def setup_method(self):
         # Base data definition.
         self.d = (MaskedArray([1.0, 0, -1, pi / 2] * 2, mask=[0, 1] + [0] * 6),
                   MaskedArray([1.0, 0, -1, pi / 2] * 2, mask=[1, 0] + [0] * 6),)
         self.err_status = np.geterr()
         np.seterr(divide='ignore', invalid='ignore')
 
-    def teardown(self):
+    def teardown_method(self):
         np.seterr(**self.err_status)
 
     def test_testUfuncRegression(self):
@@ -1625,7 +1625,7 @@ class TestUfuncs:
 class TestMaskedArrayInPlaceArithmetics:
     # Test MaskedArray Arithmetics
 
-    def setup(self):
+    def setup_method(self):
         x = MaskedArray(np.arange(10))
         y = MaskedArray(np.arange(10))
         xm = MaskedArray(np.arange(10))
@@ -2141,7 +2141,7 @@ class TestMaskedArrayInPlaceArithmetics:
 
 class TestMaskedArrayMethods:
     # Test class for miscellaneous MaskedArrays methods.
-    def setup(self):
+    def setup_method(self):
         # Base data definition.
         x = np.array([8.375, 7.545, 8.828, 8.5, 1.757, 5.928,
                       8.43, 7.78, 9.865, 5.878, 8.979, 4.732,
@@ -2684,7 +2684,7 @@ class TestMaskedArrayMethods:
 
 class TestMaskedArrayMathMethods:
 
-    def setup(self):
+    def setup_method(self):
         # Base data definition.
         x = np.array([8.375, 7.545, 8.828, 8.5, 1.757, 5.928,
                       8.43, 7.78, 9.865, 5.878, 8.979, 4.732,
@@ -2958,7 +2958,7 @@ class TestMaskedArrayMathMethods:
 
 class TestMaskedArrayMathMethodsComplex:
     # Test class for miscellaneous MaskedArrays methods.
-    def setup(self):
+    def setup_method(self):
         # Base data definition.
         x = np.array([8.375j, 7.545j, 8.828j, 8.5j, 1.757j, 5.928,
                       8.43, 7.78, 9.865, 5.878, 8.979, 4.732,
@@ -3012,7 +3012,7 @@ class TestMaskedArrayMathMethodsComplex:
 class TestMaskedArrayFunctions:
     # Test class for miscellaneous functions.
 
-    def setup(self):
+    def setup_method(self):
         x = np.array([1., 1., 1., -2., pi/2.0, 4., 5., -10., 10., 1., 2., 3.])
         y = np.array([5., 0., 3., 2., -1., -4., 0., -10., 10., 1., 0., 3.])
         m1 = [1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0]
@@ -3471,7 +3471,7 @@ class TestMaskedObjectArray:
 
 #class TestMaskedView:
 
-#    def setup(self):
+#    def setup_method(self):
 #        iterator = list(zip(np.arange(10), np.random.rand(10)))
 #        data = np.array(iterator)
 #        a = MaskedArray(iterator, dtype=[('a', float), ('b', float)])

--- a/tests/test_MaskedArray.py
+++ b/tests/test_MaskedArray.py
@@ -4255,8 +4255,8 @@ class Test_API:
         # median, percentile implemented in terms of quantile
         a = MaskedArray([2,1,4,X,3])
         assert_masked_equal(np.quantile(a, 0.5), 2.5)
-        assert_masked_equal(np.quantile(a, 0.5, interpolation='lower'), 2)
-        assert_masked_equal(np.quantile(a, 0.5, interpolation='higher'), 3)
+        assert_masked_equal(np.quantile(a, 0.5, method='lower'), 2)
+        assert_masked_equal(np.quantile(a, 0.5, method='higher'), 3)
         assert_masked_equal(np.percentile(a, 50), 2.5)
         assert_masked_equal(np.median(a), 2.5)
         assert_masked_equal(np.quantile(MaskedArray([X,X('f8')]), 0.5), X('f8'))

--- a/tests/test_MaskedArray.py
+++ b/tests/test_MaskedArray.py
@@ -2500,9 +2500,9 @@ class TestMaskedArrayMethods:
 
     def test_mask_sorting(self):
         # -1 gets converted to unsigned max val
-        a = MaskedArray([[1,X,3], [X,-1,X], [1,X,-1]], dtype='u4')
+        a = MaskedArray([[1,X,3], [X,-1,X], [1,X,-1]]).astype('u4')
         b = np.take_along_axis(a, np.argsort(a, axis=1), axis=1)
-        ctrl = MaskedArray([[1, 3, X], [-1, X, X], [1, -1, X]], dtype='u4')
+        ctrl = MaskedArray([[1, 3, X], [-1, X, X], [1, -1, X]]).astype('u4')
         assert_masked_equal(b, ctrl)
         c = a.copy()
         c.sort(axis=1)


### PR DESCRIPTION
This gets all of the MaskedArray tests working without warnings with the main numpy branch.

I'm not sure how you want to handle the floor_division tests. In plain numpy ndarrays the complex numbers now throw a TypeError, so I just skipped those for now.
d281779ed4824336b85b6aef76638ca0df69858e